### PR TITLE
Add 'called' getter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,9 @@
 {
-  extends: ['helmut']
+  extends: ['helmut'],
+  overrides: [
+    {
+      files: [ 'test.js' ],
+      env: {mocha: true, jasmine: true},
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Returns request headers. Default is {} (empty object).
 
 Returns request options. Default is {} (empty object)
 
+#### called (Boolean getter)
+
+Check whether this instance of fakeFetch was ever called
+
 #### respondWith(data, options)
 
 ##### data

--- a/index.js
+++ b/index.js
@@ -33,3 +33,11 @@ module.exports.getRequestHeaders = function () {
 module.exports.respondWith = function (data, options) {
     return window.fetch.returns(Promise.resolve(new Response(data, options)));
 };
+
+Object.defineProperty(
+    module.exports,
+    'called',
+    {
+        get: () => !!window.fetch.firstCall
+    }
+);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 module.exports = function(config) {
     config.set({
         basePath: '',
@@ -18,9 +20,9 @@ module.exports = function(config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: false,
-        browsers: ['PhantomJS'],
+        browsers: ['ChromeHeadless'],
         plugins: [
-            'karma-phantomjs-launcher',
+            'karma-chrome-launcher',
             'karma-mocha-reporter',
             'karma-jasmine',
             'karma-browserify'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.1",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-phantomjs-launcher": "^1.0.4",
-    "phantomjs-prebuilt": "^2.1.16"
+    "puppeteer": "^1.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
+    "browserify": "^16.2.3",
     "eslint-config-helmut": "^3.0.0",
     "jasmine-core": "^3.1.0",
     "karma": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -119,4 +119,17 @@ describe('Fake window.fetch', function () {
 
         expect(expectedOptions).toEqual(options);
     });
+
+    it('should detect fetch was not called', function () {
+        fakeFetch.install();
+
+        expect(fakeFetch.called).toBeFalsy();
+    });
+
+    it('should detect fetch was called', function () {
+        fakeFetch.install();
+        window.fetch('/foo');
+
+        expect(fakeFetch.called).toBeTruthy();
+    });
 });


### PR DESCRIPTION
The commits attend to some issues I've encountered (in reverse order) leading to the feature suggestion:

## Add 'called' getter (Boolean)
```js
expect(fakeFetch.called).toBeTruthy();
```

## Replace faulty phantom with the more maintained puppeteer
```
PhantomJS 2.1.1 (Mac OS X 0.0.0) ERROR: 'DEPRECATION:', 'Setting specFilter directly on Env is deprecated, please use the specFilter option in `configure`'
PhantomJS 2.1.1 (Mac OS X 0.0.0) ERROR
  {
    "message": "An error was thrown in afterAll\nSyntaxError: Unexpected token '('",
    "str": "An error was thrown in afterAll\nSyntaxError: Unexpected token '('"
  }
```

## Install 'browserify' as dev dependency. Karma error message:
```
> fake-fetch@2.0.0 test /workspace/fake-fetch
> ./node_modules/karma/bin/karma start && npm run lint

03 02 2019 16:21:10.347:ERROR [plugin]: Error during loading "karma-browserify" plugin:
  Cannot find module 'browserify'
03 02 2019 16:21:10.419:ERROR [preprocess]: Can not load "browserify", it is not registered!
  Perhaps you are missing some plugin?
03 02 2019 16:21:10.423:ERROR [karma]: Error: No provider for "framework:browserify"! (Resolving: framework:browserify)
    at error (/workspace/fake-fetch/node_modules/di/lib/injector.js:22:12)
    at Object.get (/workspace/fake-fetch/node_modules/di/lib/injector.js:9:13)
    at Injector.get (/workspace/fake-fetch/node_modules/di/lib/injector.js:54:19)
    at config.frameworks.forEach (/workspace/fake-fetch/node_modules/karma/lib/server.js:144:61)
    at Array.forEach (<anonymous>)
    at Server._start (/workspace/fake-fetch/node_modules/karma/lib/server.js:144:23)
    at Injector.invoke (/workspace/fake-fetch/node_modules/di/lib/injector.js:75:15)
    at Promise.all.then.then (/workspace/fake-fetch/node_modules/karma/lib/server.js:123:24)
    at tryCatcher (/workspace/fake-fetch/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/workspace/fake-fetch/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/workspace/fake-fetch/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/workspace/fake-fetch/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/workspace/fake-fetch/node_modules/bluebird/js/release/promise.js:694:18)
    at _drainQueueStep (/workspace/fake-fetch/node_modules/bluebird/js/release/async.js:138:12)
    at _drainQueue (/workspace/fake-fetch/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/workspace/fake-fetch/node_modules/bluebird/js/release/async.js:147:5)
npm ERR! Test failed.  See above for more details.
```


## Add [eslint environments](https://eslint.org/docs/user-guide/configuring#specifying-environments). Removes the following warnings:
```
/workspace/fake-fetch/test.js
    5:1  warning  'describe' is not defined    no-undef
    9:5  warning  'beforeEach' is not defined  no-undef
   18:5  warning  'afterEach' is not defined   no-undef
   23:5  warning  'it' is not defined          no-undef
   31:5  warning  'it' is not defined          no-undef
   40:5  warning  'it' is not defined          no-undef
   49:5  warning  'it' is not defined          no-undef
   58:5  warning  'it' is not defined          no-undef
   67:5  warning  'it' is not defined          no-undef
   76:5  warning  'it' is not defined          no-undef
   82:9  warning  'expect' is not defined      no-undef
   85:5  warning  'it' is not defined          no-undef
   97:9  warning  'expect' is not defined      no-undef
  100:5  warning  'it' is not defined          no-undef
  106:9  warning  'expect' is not defined      no-undef
  109:5  warning  'it' is not defined          no-undef
  120:9  warning  'expect' is not defined      no-undef
  123:5  warning  'it' is not defined          no-undef
  126:9  warning  'expect' is not defined      no-undef
  129:5  warning  'it' is not defined          no-undef
  133:9  warning  'expect' is not defined      no-undef

✖ 21 problems (0 errors, 21 warnings)
```
